### PR TITLE
fix: improve plan prompt to prefer extending existing systems

### DIFF
--- a/builtin/prompts/plan.md
+++ b/builtin/prompts/plan.md
@@ -26,6 +26,7 @@ Generate a multiple step plan in the `./issues` folder of multiple `<nnnnnn>_ste
 
 - DO Follow the Coding Standards
 - DO NOT code at this step, we are just creating the plan
+- DO make sure to review the existing codebase and architecture before creating the implementation plan
 - DO make sure each step file is a single focused task
 - DO create many, small step files. Ideally each step should result in less than 500 lines of code changed
 - Any time you create a step file, it should use the next number larger than all other issues
@@ -52,7 +53,7 @@ Generate a multiple step plan in the `./issues` folder of multiple `<nnnnnn>_ste
 {% endif %}
 - Use git to determine what has changed in the specification compared to what has already been planned.
 - Review the existing memos and think deeply about how they apply to the plan.
-- Review the existing code to determine what parts of the specification might already be implemented.
+- Review the existing code to determine what parts of the specification might already be implemented.  Unless explicitly instructed otherwise in the specification, do not add new systems/services when existing patterns and systems can be extended to achieve the goals.
 - Draft a detailed, step-by-step plan to meet the specification, write this out to a temp file `.swissarmyhammer/tmp/DRAFT_PLAN.md`, refer to this draft plan to refresh your memory.
 - Then, once you have a draft plan, break it down into small, iterative chunks that build on each other incrementally.
 - Look at these chunks and then go another round to break it into small steps.


### PR DESCRIPTION
## Problem

I've found that when adding new features to an existing project, the plan workflow sometimes generates inappropriate implementation plans that add undue complexity.   For example, creating new parallel systems where it would make more sense to extend or leverage existing code. 

### Example of Observed Issue
To demonstrate the problem, I replicated it with a new spec for making a change to the SAH cli to add periodic, formatted logging of the progress.   When I ran `sah flow run plan`, the resulting issues:
- Created a new event system (when SAH has existing workflow execution events)
- created a new configuration system (when SAH has comprehensive `sah_config` module)  
- created a new todo tracking (when SAH has mature todo storage system)
- Ignored existing todo, workflow, MCP, and configuration systems
- Violated the "DO NOT duplicate" coding standard

## Root Cause

The plan prompt didn't adequately emphasize:
1. Reviewing existing codebase architecture before planning
2. Preferring extension of existing systems over creating new ones

This led to greenfield planning approaches that ignored existing patterns and violated architectural principles.

## Solution

Enhanced the plan prompt with two targeted additions:

### 1. Guidelines Section
```markdown
- DO make sure to review the existing codebase and architecture before creating the implementation plan
```

### 2. Process Section  
```markdown
Unless explicitly instructed otherwise in the specification, do not add new systems/services when existing patterns and systems can be extended to achieve the goals.
```
