### PR TITLE
offer a sensible default when prompting user for plan_filename

### DIFF
--- a/builtin/workflows/plan.md
+++ b/builtin/workflows/plan.md
@@ -8,6 +8,7 @@ parameters:
     description: Path to the specification file to process
     required: true
     type: string
+    default: specification/index.md
     pattern: '^.*\.md$'
 
 parameter_groups:

--- a/swissarmyhammer/src/common/interactive_prompts.rs
+++ b/swissarmyhammer/src/common/interactive_prompts.rs
@@ -334,10 +334,12 @@ impl InteractivePrompts {
         let mut input_prompt = Input::<String>::with_theme(&theme)
             .with_prompt(format!("Enter {} ({})", param.name, param.description));
 
-        // Add default value if available
+        // Add default value if available and show it in the prompt
         if let Some(default) = &param.default {
             if let Some(default_str) = default.as_str() {
-                input_prompt = input_prompt.default(default_str.to_string());
+                input_prompt = input_prompt
+                    .default(default_str.to_string())
+                    .show_default(true);
             }
         }
 

--- a/swissarmyhammer/src/common/parameters.rs
+++ b/swissarmyhammer/src/common/parameters.rs
@@ -989,9 +989,21 @@ impl DefaultParameterResolver {
                 };
 
                 if should_include {
-                    // Check if we can use a default value, regardless of whether it's required
-                    if let Some(default) = &param.default {
-                        // Use default value for parameters when condition is met
+                    // In interactive mode, prompt even if a default exists so the user can confirm/override
+                    if interactive {
+                        // Explicitly prompt for the parameter (even if a default exists)
+                        let interactive_prompts =
+                            crate::common::interactive_prompts::InteractivePrompts::new(false);
+
+                        match interactive_prompts.prompt_with_error_recovery(param) {
+                            Ok(value) => {
+                                resolved.insert(param.name.clone(), value);
+                                changed = true;
+                            }
+                            Err(e) => return Err(e),
+                        }
+                    } else if let Some(default) = &param.default {
+                        // Non-interactive: use default value when available
                         resolved.insert(param.name.clone(), default.clone());
                         changed = true;
                     } else if param.required {


### PR DESCRIPTION
When the user runs `sah flow run plan`, the user is currently asked to enter the path to their spec markdown file. Interactive runs don’t show a suggested default for plan_filename, making the UX less clear.

```bash
(venv) ➜  cloakpivot git:(main) sah flow run plan
✔ Enter plan_filename (Path to the specification file to process) · specification/index.md

```

This PR proposes a minor change to allow the user to just type "enter" to proceed with the default spec file path: `specification/index.md`

This way the user doesn't have to type anything unless they are explicitly wanting to use a spec file that isn't `specification/index.md`

### changes
`builtin/workflows/plan.md`: add `default: specification/index.md` to `plan_filename`.

`swissarmyhammer/src/common/interactive_prompts.rs`: use dialoguer’s `.show_default(true)` so the default is displayed in the prompt.

`swissarmyhammer/src/common/parameters.rs`: in interactive runs, call the type-aware prompt path even if a default exists to ensure the user can either confirm (hit "enter") or override by typing the path to another spec file they want to use


I _think_ i did this correctly...I tested manually by building the CLI, creating a fresh project and testing with and without a custom spec markdown file. 
