### PR TITLE
fix(release): consistent formula names, unblock cask publish, stop kanban build hang

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -21,16 +21,33 @@ on:
         description: "Release tag (e.g. v0.1.0)"
         required: true
 
+# Only one Release App run at a time on the single self-hosted runner. If a new
+# release starts while an old run is still grinding (or hung), cancel the old
+# one so it stops squatting the runner and leaving orphan cargo/rustc behind.
+concurrency:
+  group: release-app
+  cancel-in-progress: true
+
 jobs:
   build-macos:
     # Skip if workflow_run triggered by a failed/cancelled Release
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
     runs-on: self-hosted
-    # The build/sign/notarize phase has hung silently for 6+ hours on past
-    # runs (zero output after "Compiling <app>", then an external cancel),
-    # tying up the single self-hosted runner. Cap the job so a hung build
-    # fails fast and frees the runner instead of squatting on it.
-    timeout-minutes: 30
+    # Past kanban runs hung for 4-6h with zero output. Root cause (from the
+    # logs) is NOT code signing -- the build never reaches it. It thrashes in
+    # the *cargo compile* phase: the kanban app's dependency graph (Tauri's
+    # wry/webkit GUI stack + the swissarmyhammer-agent/llama.cpp stack, the
+    # latter built twice -- once for the CLI sidecar, once for the app) peaks
+    # past the runner's RAM and swaps to death. release.yml compiles the same
+    # llama stack for the CLI in ~14m, so the fix is to bound peak memory
+    # (CARGO_BUILD_JOBS on the build step) rather than touch signing.
+    #
+    # NOTE: this job-level timeout-minutes does NOT reliably fire on the
+    # self-hosted runner (past hangs ran 4-6h despite a 30m cap), so the build
+    # step additionally wraps cargo in an OS-level watchdog. This value is just
+    # a backstop; it is generous because a healthy app build legitimately takes
+    # ~40-70m at reduced parallelism.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -70,6 +87,18 @@ jobs:
       - name: Install Rust toolchain
         run: |
           rustup target add aarch64-apple-darwin
+
+      - name: Free the runner (kill stale build processes)
+        # This is a persistent self-hosted runner. Past hung runs were cancelled
+        # without their cargo/rustc/cc children being reaped, so they kept
+        # running and saturating RAM -- making the next build thrash too (a
+        # self-perpetuating doom loop). Reap any stragglers before we start.
+        # max-parallel:1 + the concurrency group guarantee no sibling build is
+        # legitimately running, so this is safe.
+        run: |
+          pkill -9 -f 'cargo-tauri|cargo|rustc|llama' 2>/dev/null || true
+          sleep 2
+          echo "Free memory before build:"; vm_stat | head -5 || true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -113,12 +142,38 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # Bound peak memory: the kanban app graph (GUI + agent/llama, the
+          # llama stack compiled twice) OOM-thrashed the runner at full
+          # parallelism and hung for hours. Capping concurrent codegen units
+          # keeps the resident set under the runner's RAM. release.yml builds
+          # the same stack fine, so this only needs to be conservative, not
+          # tiny. Tune up if the runner gets more RAM.
+          CARGO_BUILD_JOBS: "4"
         working-directory: ${{ matrix.app.dir }}
         run: |
+          # OS-level watchdog: the job-level timeout-minutes does NOT fire on
+          # this self-hosted runner (past hangs ran 4-6h under a 30m cap), so a
+          # hung build would squat the runner indefinitely. Run the build in the
+          # background and hard-kill the whole cargo/rustc tree if it blows past
+          # the limit, so the step fails fast and frees the runner.
           # --verbose so the bundle/codesign/notarize phase emits progress.
-          # Without it Tauri prints nothing after compilation, which is why a
-          # hang here showed up as 6 hours of silence with no clue where.
+          WATCHDOG_SECONDS=5400  # 90 minutes
+          (
+            sleep "$WATCHDOG_SECONDS"
+            echo "::error::Tauri build exceeded ${WATCHDOG_SECONDS}s watchdog -- killing cargo/rustc (likely OOM/swap thrash)."
+            pkill -9 -f 'cargo-tauri|cargo|rustc|llama' 2>/dev/null || true
+          ) &
+          watchdog_pid=$!
+
+          set +e
           cargo tauri build --verbose --target aarch64-apple-darwin
+          status=$?
+          set -e
+
+          # Build finished (or was killed) -- stop the watchdog.
+          kill "$watchdog_pid" 2>/dev/null || true
+          wait "$watchdog_pid" 2>/dev/null || true
+          exit "$status"
 
       - name: Verify app bundle
         run: |

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -186,6 +186,14 @@ jobs:
 
   publish-homebrew-cask:
     needs: build-macos
+    # Run even when build-macos partially failed: each app is its own matrix
+    # leg here and downloads only its own DMG artifact, so a failed/hung build
+    # for one app (e.g. the kanban Tauri build) must not block publishing the
+    # cask for an app that built fine (e.g. mirdan). Previously `needs:
+    # build-macos` with the default `if` skipped this whole job whenever any
+    # build leg failed -- which is why BOTH casks were frozen for months while
+    # only kanban was actually broken. Skip only if build-macos never ran.
+    if: ${{ always() && needs.build-macos.result != 'skipped' }}
     runs-on: self-hosted
     timeout-minutes: 15
     strategy:
@@ -218,13 +226,23 @@ jobs:
           echo "value=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Download DMG artifact
+        id: dl
+        # The build leg only uploads this artifact on success. If that app's
+        # build failed, the download fails -- tolerate it so this leg skips
+        # cleanly instead of erroring, while other apps' legs still publish.
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.app.name }}-app-dmg
           path: dmg/
 
+      - name: No DMG -- skipping this app
+        if: ${{ steps.dl.outcome != 'success' }}
+        run: echo "No DMG artifact for ${{ matrix.app.name }} (build failed or skipped); not publishing its cask."
+
       - name: Compute SHA256
         id: sha
+        if: ${{ steps.dl.outcome == 'success' }}
         run: |
           DMG=$(find dmg -name "*.dmg" | head -1)
           SHA=$(shasum -a 256 "$DMG" | cut -d' ' -f1)
@@ -234,6 +252,7 @@ jobs:
           echo "SHA256: $SHA for $NAME"
 
       - name: Checkout swissarmyhammer
+        if: ${{ steps.dl.outcome == 'success' }}
         uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -241,6 +260,7 @@ jobs:
           path: swissarmyhammer
 
       - name: Checkout homebrew-tap
+        if: ${{ steps.dl.outcome == 'success' }}
         uses: actions/checkout@v4
         with:
           persist-credentials: true
@@ -249,6 +269,7 @@ jobs:
           path: homebrew-tap
 
       - name: Update cask
+        if: ${{ steps.dl.outcome == 'success' }}
         env:
           VERSION: ${{ steps.tag.outputs.value }}
           SHA256: ${{ steps.sha.outputs.sha256 }}
@@ -284,6 +305,7 @@ jobs:
             > homebrew-tap/Casks/${{ matrix.app.name }}.rb
 
       - name: Push cask
+        if: ${{ steps.dl.outcome == 'success' }}
         working-directory: homebrew-tap
         run: |
           git config user.name "mirdan bot"

--- a/apps/avp-cli/Cargo.toml
+++ b/apps/avp-cli/Cargo.toml
@@ -7,8 +7,9 @@ repository.workspace = true
 homepage.workspace = true
 description = "Agent Validator Protocol - Claude Code hook processor CLI"
 
+# No `formula = "..."` override: the formula is named after the crate
+# (`avp-cli`), consistent with every other CLI in the workspace.
 [package.metadata.dist]
-formula = "avp"
 
 [lib]
 name = "avp"

--- a/apps/code-context-cli/Cargo.toml
+++ b/apps/code-context-cli/Cargo.toml
@@ -7,8 +7,9 @@ repository.workspace = true
 homepage.workspace = true
 description = "Standalone MCP code-context tool CLI for AI coding agents"
 
+# No `formula = "..."` override: the formula is named after the crate
+# (`code-context-cli`), consistent with every other CLI in the workspace.
 [package.metadata.dist]
-formula = "code-context"
 
 [[bin]]
 name = "code-context"

--- a/apps/kanban-cli/Cargo.toml
+++ b/apps/kanban-cli/Cargo.toml
@@ -5,10 +5,15 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 description = "kanban — a git-native task board for humans and AI coding agents; CLI + MCP server over versionable .kanban/ files"
 
+# No `formula = "..."` override: the Homebrew formula is named after the crate
+# (`kanban-cli`). The short `kanban` token belongs to the desktop app cask
+# (apps/kanban-app), which bundles this CLI as a sidecar. An override here would
+# recreate the formula/cask name collision that made `brew install kanban` pull
+# the CLI instead of the app.
 [package.metadata.dist]
-formula = "kanban"
 
 [[bin]]
 name = "kanban"

--- a/apps/mirdan-cli/Cargo.toml
+++ b/apps/mirdan-cli/Cargo.toml
@@ -11,8 +11,11 @@ description = "Mirdan CLI - Command-line interface for the Mirdan package manage
 name = "mirdan"
 path = "src/main.rs"
 
+# No `formula = "..."` override: the Homebrew formula is named after the crate
+# (`mirdan-cli`). The short `mirdan` token belongs to the desktop app cask
+# (apps/mirdan-app). An override here would collide the CLI formula with the app
+# cask, same bug as kanban.
 [package.metadata.dist]
-formula = "mirdan"
 
 [dependencies]
 mirdan = { workspace = true }

--- a/apps/shelltool-cli/Cargo.toml
+++ b/apps/shelltool-cli/Cargo.toml
@@ -7,8 +7,9 @@ repository.workspace = true
 homepage.workspace = true
 description = "Standalone MCP shell tool CLI for AI coding agents"
 
+# No `formula = "..."` override: the formula is named after the crate
+# (`shelltool-cli`), consistent with every other CLI in the workspace.
 [package.metadata.dist]
-formula = "shelltool"
 
 [[bin]]
 name = "shelltool"

--- a/apps/swissarmyhammer-cli/Cargo.toml
+++ b/apps/swissarmyhammer-cli/Cargo.toml
@@ -13,8 +13,14 @@ homepage.workspace = true
 description = "Command-line interface for SwissArmyHammer prompt management"
 default-run = "sah"
 
+# Distributed via Homebrew as the `swissarmyhammer-cli` formula (binary `sah`).
+# Naming is consistent across the workspace: every CLI crate is `*-cli` and
+# ships a `<name>-cli` formula; GUI apps own the short cask token. Do NOT add a
+# `formula = "..."` override here -- that is exactly what made the tap
+# inconsistent (short formulae colliding with app casks, plus uncollected
+# rename fossils).
 [package.metadata.dist]
-dist = false
+dist = true
 
 [lib]
 name = "swissarmyhammer_cli"


### PR DESCRIPTION
Fixes the whole release/tap pipeline, which had drifted badly.

## 1. Consistent Homebrew CLI formula names
A half-finished migration added `formula = "<short>"` overrides to 5 CLI crates (kanban, avp, code-context, shelltool, mirdan) while `swissarmyhammer-cli` was set `dist = false`. cargo-dist never GCs renamed-away formulae, so the tap accumulated fossils (`kanban-cli.rb` + `kanban.rb`, …), `swissarmyhammer` fell off brew entirely, and the short formula names **collided with the app casks** — `brew install kanban`/`mirdan` resolved to the CLI formula, not the desktop app.

**One rule for the whole workspace: CLI = `<name>-cli` formula, app = short `<name>` cask.**
- Drop all 5 `formula =` overrides (crate names are already `*-cli`).
- Re-enable `swissarmyhammer-cli` dist; add kanban-cli's missing `homepage`.
- Verified with `dist plan`: emits exactly `swissarmyhammer-cli, kanban-cli, avp-cli, code-context-cli, shelltool-cli, mirdan-cli` — nothing collides with a cask.

## 2. Unblock cask publishing
`publish-homebrew-cask` gated on the whole `build-macos` matrix, so the hung kanban build cancelled mirdan's cask push too — both casks were frozen ~3 months. Each app now downloads only its own DMG and publishes independently; a missing DMG skips that app cleanly.

## 3. Stop the kanban app build hanging (the real reason kanban-app is stale)
The kanban Tauri build hung 4–6h every release; the prior fix blamed code signing. The logs prove it stalls in the **cargo compile** phase (`Compiling swissarmyhammer-agent`, then hours of silence). Root cause: kanban-app pulls the `swissarmyhammer-agent`/llama.cpp stack (compiled **twice** — sidecar + app) plus Tauri's GUI tree; at full parallelism peak memory exceeds the self-hosted runner's RAM and it swaps to death. (release.yml compiles the same stack for the CLI in ~14m, so the stack is fine.)
- `CARGO_BUILD_JOBS=4` to bound peak memory (the actual fix).
- OS-level watchdog (pkill after 90m) since the job `timeout-minutes` doesn't fire on this runner; backstop raised to 120m.
- Reap stale cargo/rustc before building (cancelled runs left orphans saturating the runner → doom loop).
- `concurrency: cancel-in-progress` so a new release cancels an old hung run.

⚠️ Parts 2 & 3 can only be fully validated by a real release on the self-hosted runner.

## Follow-ups (not in this PR)
1. **Prune 5 tap fossils** after the first release on this config regenerates the `*-cli.rb`: delete `kanban.rb`, `avp.rb`, `code-context.rb`, `shelltool.rb`, `mirdan.rb` (Formula). Doing it before that release would break `brew install` with no replacement. (`kanban-app.rb`/`mirdan-app.rb` already deleted.)
2. **Eliminate the double-compile**: the sidecar build and app build don't share the dep cache (the llama stack compiles twice). Likely a RUSTFLAGS/target mismatch, or the sidecar could just download the CLI tarball release.yml already built. Would roughly halve the build.
