### PR TITLE
fix(release): correct cask sha contamination + brew-install docs

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           rustup target add aarch64-apple-darwin
 
-      - name: Free the runner (kill stale build processes)
+      - name: Free the runner (kill stale build processes + stale bundle output)
         # This is a persistent self-hosted runner. Past hung runs were cancelled
         # without their cargo/rustc/cc children being reaped, so they kept
         # running and saturating RAM -- making the next build thrash too (a
@@ -98,6 +98,13 @@ jobs:
         run: |
           pkill -9 -f 'cargo-tauri|cargo|rustc|llama' 2>/dev/null || true
           sleep 2
+          # The matrix legs share this reused workspace and all write to the
+          # same bundle output dir. If a prior app's .dmg/.app lingers here, the
+          # later "find ... | head -1" steps can pick the WRONG app's artifact
+          # (this shipped a kanban cask carrying mirdan's DMG sha256, which made
+          # `brew install --cask kanban` fail checksum verification). Wipe the
+          # bundle output so each leg only ever sees its own freshly built one.
+          rm -rf target/aarch64-apple-darwin/release/bundle
           echo "Free memory before build:"; vm_stat | head -5 || true
 
       - name: Setup Node.js
@@ -289,7 +296,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.app.name }}-app-dmg
-          path: dmg/
+          # Per-app download dir, NOT a shared `dmg/`. The publish legs run
+          # sequentially on the reused self-hosted workspace; a shared dir let a
+          # prior leg's DMG linger so `find dmg ... | head -1` hashed the wrong
+          # app's file (the kanban cask shipped mirdan's sha256). A unique path
+          # per leg guarantees this leg only ever sees its own DMG.
+          path: dmg-${{ matrix.app.name }}/
 
       - name: No DMG -- skipping this app
         if: ${{ steps.dl.outcome != 'success' }}
@@ -299,7 +311,7 @@ jobs:
         id: sha
         if: ${{ steps.dl.outcome == 'success' }}
         run: |
-          DMG=$(find dmg -name "*.dmg" | head -1)
+          DMG=$(find "dmg-${{ matrix.app.name }}" -name "*.dmg" | head -1)
           SHA=$(shasum -a 256 "$DMG" | cut -d' ' -f1)
           NAME=$(basename "$DMG")
           echo "sha256=$SHA" >> "$GITHUB_OUTPUT"

--- a/apps/kanban-app/tests/cask_gen.rs
+++ b/apps/kanban-app/tests/cask_gen.rs
@@ -7,8 +7,8 @@
 //!
 //! * `kanban` — passes `--cli-binary Contents/MacOS/kanban`, so the rendered
 //!   cask must additionally carry a `binary` stanza (symlinking the bundled
-//!   CLI onto PATH) and a `conflicts_with formula: "kanban"` stanza (so the
-//!   standalone cargo-dist `kanban` formula and the cask never both own
+//!   CLI onto PATH) and a `conflicts_with formula: "kanban-cli"` stanza (so the
+//!   standalone cargo-dist `kanban-cli` formula and the cask never both own
 //!   `kanban` on PATH).
 //! * `mirdan` — no `--cli-binary`, so neither stanza may appear.
 //!
@@ -144,9 +144,12 @@ fn kanban_cask_has_binary_stanza() {
     );
 }
 
-/// The `kanban` invocation must render a `conflicts_with formula: "kanban"`
-/// stanza so the cask and the standalone cargo-dist formula never both own
-/// the `kanban` symlink on PATH.
+/// The `kanban` invocation must render a `conflicts_with formula: "kanban-cli"`
+/// stanza so the cask and the standalone cargo-dist formula never both own the
+/// `kanban` symlink on PATH. The formula is named `kanban-cli` (workspace
+/// convention: CLIs are `*-cli`, the short token is the app cask), so the
+/// conflict must name that formula -- not the cask token "kanban", which is a
+/// formula that does not exist.
 #[test]
 fn kanban_cask_has_conflicts_with_formula() {
     let mut args = kanban_args();
@@ -154,8 +157,8 @@ fn kanban_cask_has_conflicts_with_formula() {
     let cask = render_cask(&args);
 
     assert!(
-        cask.contains(r#"conflicts_with formula: "kanban""#),
-        "kanban cask must declare a conflict with the standalone kanban formula; got:\n{cask}",
+        cask.contains(r#"conflicts_with formula: "kanban-cli""#),
+        "kanban cask must declare a conflict with the standalone kanban-cli formula; got:\n{cask}",
     );
 }
 

--- a/apps/kanban-cli/README.md
+++ b/apps/kanban-cli/README.md
@@ -88,7 +88,7 @@ No GUI — just the `kanban` binary (CLI + MCP server). The right choice for ser
 **macOS / Linux (Homebrew formula):**
 
 ```bash
-brew install swissarmyhammer/tap/kanban
+brew install swissarmyhammer/tap/kanban-cli
 ```
 
 **Linux (install script):**
@@ -103,7 +103,7 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/swissarmyhammer/swissar
 cargo install --git https://github.com/swissarmyhammer/swissarmyhammer kanban-cli
 ```
 
-> On macOS the cask (Option A) and the formula (Option B) both provide a `kanban` command, so the cask declares `conflicts_with formula: "kanban"` — they never fight over your `PATH`. Pick the cask if you want the GUI, the formula if you only want the CLI.
+> On macOS the cask (Option A) and the `kanban-cli` formula (Option B) both provide a `kanban` command, so the cask declares `conflicts_with formula: "kanban-cli"` — they never fight over your `PATH`. Pick the cask if you want the GUI, the formula if you only want the CLI. (`brew install …/kanban` with no `--cask` resolves to the app cask, since the short `kanban` name belongs to the app.)
 
 ### Build the app from source
 

--- a/apps/mirdan-cli/README.md
+++ b/apps/mirdan-cli/README.md
@@ -14,8 +14,17 @@ Mirdan manages skills and validators for AI coding agents. Install community pac
 
 ### macOS (Homebrew)
 
+The CLI (this package manager):
+
 ```bash
-brew install swissarmyhammer/tap/mirdan
+brew install swissarmyhammer/tap/mirdan-cli
+```
+
+Prefer the menu-bar tray app? That's a separate cask (GUI only — it does **not**
+put the `mirdan` CLI on your `PATH`):
+
+```bash
+brew install --cask swissarmyhammer/tap/mirdan
 ```
 
 ### Linux

--- a/build-support/gen-cask.sh
+++ b/build-support/gen-cask.sh
@@ -95,7 +95,12 @@ if [ -n "$cli_binary" ]; then
     # `#{appdir}` is a Homebrew interpolation evaluated by Ruby at install
     # time, not a shell expansion — emit it literally.
     printf '  binary "#{appdir}/%s.app/%s"\n' "$product" "$cli_binary"
-    printf '  conflicts_with formula: "%s"\n' "$name"
+    # The standalone CLI ships as the `<name>-cli` formula (workspace
+    # convention: CLIs are `*-cli`, the short token is the app cask). Conflict
+    # against that real formula name, not the cask token "$name" -- a cask and a
+    # formula can share a token, so `conflicts_with formula: "$name"` would name
+    # a formula that does not exist and never guard the PATH symlink clash.
+    printf '  conflicts_with formula: "%s-cli"\n' "$name"
 fi
 
 printf 'end\n'


### PR DESCRIPTION
Follow-up to #53. Started as "make the app install instructions point at the cask," but uncovered a live cask bug while verifying.

## 1. Live bug: kanban cask had the wrong sha256
Both casks recorded the **same** `sha256` (`218783466b…` — mirdan's DMG). The real `Kanban_aarch64.dmg` (51 MB) hashes to `42ce2dcb…`, so `brew install --cask swissarmyhammer/tap/kanban` downloaded the correct DMG and **failed checksum verification**.

**Cause:** the `publish-homebrew-cask` matrix legs run sequentially on the reused self-hosted workspace and shared a `dmg/` dir, so `find dmg -name '*.dmg' | head -1` hashed whichever DMG lingered from the other leg. The `build-macos` legs share the bundle output dir the same way (latent).
- publish: download each app's DMG to a per-app `dmg-<name>/` dir, hash from there.
- build: wipe `target/<triple>/release/bundle` before each build (in the existing "Free the runner" step).
- The already-shipped kanban cask in the tap was hand-corrected to `42ce2dcb…`, so `--cask kanban` works now.

## 2. `conflicts_with` named a formula that doesn't exist
After the `-cli` rename the CLI is `kanban-cli`, but `gen-cask.sh` still emitted `conflicts_with formula: "kanban"` — a formula that no longer exists, so it never guarded the PATH clash between the cask's `kanban` symlink and the `kanban-cli` formula's. Now emits `<name>-cli`; `cask_gen.rs` updated (5/5 tests pass).

## 3. Install docs corrected
`brew install …/kanban` and `…/mirdan` (no `--cask`) now resolve to the **app casks**, so the old CLI instructions were wrong.
- `apps/kanban-cli/README.md`: formula install → `kanban-cli`; conflicts note → `kanban-cli`.
- `apps/mirdan-cli/README.md`: split **CLI** (`brew install …/mirdan-cli`) from the **tray app** (`brew install --cask …/mirdan` — GUI only, does not put the CLI on PATH).

⚠️ Parts 1 & 2 only take effect in the tap on the next release; the live tap was already hand-fixed for the sha.
