### PR TITLE
fix(release): stop aarch64-linux build OOM (disable dist LTO + cap jobs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,11 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      # Cap concurrent codegen units so peak compile memory stays under the
+      # runner's RAM. The aarch64-unknown-linux-gnu leg cross-compiles the
+      # heavy llama.cpp/ggml C++ stack and was OOM-killed at full parallelism
+      # (manually edited here; dist-workspace.toml sets allow-dirty = ["ci"]).
+      CARGO_BUILD_JOBS: "3"
     steps:
       - name: enable windows longpaths
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -369,5 +369,12 @@ split-debuginfo = "unpacked"
 
 [profile.dist]
 inherits = "release"
-lto = true
+# LTO disabled deliberately. Fat LTO link-time optimization of the full
+# llama.cpp/ggml + agent dependency tree blew past the GitHub runner's memory
+# on the cross-compiled aarch64-unknown-linux-gnu release build -- the "Build
+# artifacts" step was OS-killed mid-link with zero log output (the OOM
+# signature), which silently failed every release. Plain release optimization
+# (opt-level 3, codegen-units 16) builds fine on every target. Revisit `thin`
+# LTO only if a release runner with more headroom is available.
+lto = false
 strip = true


### PR DESCRIPTION
The aarch64-unknown-linux-gnu release leg is OS-killed (OOM) cross-compiling the llama.cpp/ggml C++ stack with fat LTO over the whole tree — the "Build artifacts" step dies with zero log output, on two consecutive v0.13.9 attempts, blocking the entire release (host/publish/announce skipped). Not a code regression: nothing buildable changed since v0.13.8 succeeded.

- `profile.dist`: `lto = true` -> `false` (fat LTO link is the memory hog).
- `release.yml`: `CARGO_BUILD_JOBS=3` to bound peak compile memory.

Needs a release (v0.13.10) to confirm. If it still dies it is disk, not RAM (that would print "No space"), and the fix is a disk-reclaim step.